### PR TITLE
fix: remove deprecated `main` field

### DIFF
--- a/package_build.json
+++ b/package_build.json
@@ -2,7 +2,6 @@
   "name": "node-masker",
   "version": "1.0.8",
   "description": "node-masker is a javascript mask library make in TypeScript",
-  "main": "build/index.js",
   "repository": "git@github.com:marcelodosreis/node-masker.git",
   "author": "marcelodosreis <marcelohrpaulo13@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
# Deprecated `package.json` field

The `package.json` field called `main` was deprecated in node v12 and was causing the following warning:

```
[DEP0128] DeprecationWarning: Invalid 'main' field in 'node_modules/node-masker/package.json' of 'build/index.js'. Please either fix that or report it to the module author
```
Removing the field, fixed the warning.
As we have an `index.js` in root directory, this field is not required.
